### PR TITLE
feat: CORS 허용 및 Preflight 요청 처리 추가

### DIFF
--- a/src/main/java/com/lion/CalPick/config/SecurityConfig.java
+++ b/src/main/java/com/lion/CalPick/config/SecurityConfig.java
@@ -49,8 +49,8 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        http
-            .csrf(csrf -> csrf.disable())
+        http.cors(Customizer.withDefaults())
+            .csrf(AbstractHttpConfigurer::disable)
             .exceptionHandling(exception -> exception.authenticationEntryPoint(unauthorizedHandler))
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(authorize -> authorize

--- a/src/main/java/com/lion/CalPick/config/SecurityConfig.java
+++ b/src/main/java/com/lion/CalPick/config/SecurityConfig.java
@@ -3,30 +3,33 @@ package com.lion.CalPick.config;
 import com.lion.CalPick.repository.UserRepository;
 import com.lion.CalPick.service.CustomUserDetailsService;
 import com.lion.CalPick.util.JwtTokenProvider;
+import org.springframework.web.cors.CorsUtils;
+import org.springframework.web.filter.CorsFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
 
-    private final UserRepository userRepository;
     private final JwtAuthenticationEntryPoint unauthorizedHandler;
     private final CustomUserDetailsService customUserDetailsService;
     private final JwtTokenProvider jwtTokenProvider;
 
     public SecurityConfig(UserRepository userRepository, JwtAuthenticationEntryPoint unauthorizedHandler, CustomUserDetailsService customUserDetailsService, JwtTokenProvider jwtTokenProvider) {
-        this.userRepository = userRepository;
         this.unauthorizedHandler = unauthorizedHandler;
         this.customUserDetailsService = customUserDetailsService;
         this.jwtTokenProvider = jwtTokenProvider;

--- a/src/main/java/com/lion/CalPick/config/SecurityConfig.java
+++ b/src/main/java/com/lion/CalPick/config/SecurityConfig.java
@@ -1,6 +1,5 @@
 package com.lion.CalPick.config;
 
-import com.lion.CalPick.domain.User;
 import com.lion.CalPick.repository.UserRepository;
 import com.lion.CalPick.service.CustomUserDetailsService;
 import com.lion.CalPick.util.JwtTokenProvider;
@@ -12,8 +11,6 @@ import org.springframework.security.config.annotation.authentication.configurati
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -46,14 +43,6 @@ public class SecurityConfig {
     }
 
     @Bean
-    public DaoAuthenticationProvider authenticationProvider() {
-        DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider();
-        authProvider.setUserDetailsService(customUserDetailsService);
-        authProvider.setPasswordEncoder(passwordEncoder());
-        return authProvider;
-    }
-
-    @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
         return authenticationConfiguration.getAuthenticationManager();
     }
@@ -70,9 +59,7 @@ public class SecurityConfig {
                 .requestMatchers("/api/schedules/**").authenticated()
                 .anyRequest().authenticated()
             )
-            .authenticationProvider(authenticationProvider());
-
-        http.addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+            .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/lion/CalPick/config/SecurityConfig.java
+++ b/src/main/java/com/lion/CalPick/config/SecurityConfig.java
@@ -62,4 +62,19 @@ public class SecurityConfig {
 
         return http.build();
     }
+
+    @Bean
+    public CorsFilter corsFilter() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(true);
+        config.addAllowedOrigin("http://localhost:5173"); // React 개발 서버 주소
+        config.addAllowedHeader("*");
+        config.addAllowedMethod("*");
+        config.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+
+        return new CorsFilter(source);
+    }
 }

--- a/src/main/java/com/lion/CalPick/config/SecurityConfig.java
+++ b/src/main/java/com/lion/CalPick/config/SecurityConfig.java
@@ -55,8 +55,7 @@ public class SecurityConfig {
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(authorize -> authorize
                 .requestMatchers("/api/auth/**").permitAll()
-                .requestMatchers("/api/friends/**").authenticated()
-                .requestMatchers("/api/schedules/**").authenticated()
+                    .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
                 .anyRequest().authenticated()
             )
             .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);


### PR DESCRIPTION
## 📌 작업 내용  
- **`DaoAuthenticationProvider` 관련 설정 제거**
    - Spring Security 6에서 deprecated 되어 더 이상 사용하지 않음
    - 관련 `@Bean` 메서드 및 `SecurityFilterChain` 내 설정 제거

- **CORS 설정 추가**
    - `http.cors(Customizer.withDefaults())` 적용
    - Preflight 요청(OPTIONS) 허용을 위해 `CorsUtils::isPreFlightRequest` 명시

- `csrf` 설정 방식 개선
    - 기존 `.csrf(csrf -> csrf.disable()) → AbstractHttpConfigurer::disable`로 변경
    
- **전역 CORS 필터 추가**
    - `CorsFilter Bean` 등록하여 프론트 주소 허용
    - 모든 메서드, 헤더 허용 및 credentials 설정 추가

- **불필요한 import 정리**

---

## 🔜 앞으로의 과제  
- JWT 토큰 인증 흐름 점검
- 보안 설정 모듈 리팩토링 (e.g. CORS 설정 별도 클래스로 분리)
- 프로덕션 환경용 도메인 설정 및 CORS 분기 처리

---

## 📎 참고 사항 (선택)  
- `CorsFilter`를 직접 등록했기 때문에 `spring.mvc.cors` 설정은 적용되지 않습니다.
- `DaoAuthenticationProvider` 제거로 인한 인증 흐름은 문제 없이 동작하는지 꼭 확인 부탁드립니다.
- Preflight 요청 허용 설정(`CorsUtils`)이 없으면 프론트 요청이 계속 403으로 막힙니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for cross-origin requests, allowing credentials and requests from "http://localhost:5173".

* **Refactor**
  * Streamlined security configuration for better handling of authentication and authorization.
  * Enhanced handling of preflight CORS requests.

* **Bug Fixes**
  * Removed unused components to improve application performance and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->