### PR TITLE
달력 내 일정 조회부분 수정(jpql방식)

### DIFF
--- a/src/main/java/com/lion/CalPick/controller/AuthController.java
+++ b/src/main/java/com/lion/CalPick/controller/AuthController.java
@@ -21,6 +21,7 @@ public class AuthController {
     @PostMapping("/signup")
     public ResponseEntity<?> signup(@RequestBody SignUpRequest signupRequest) {
         try {
+            System.out.println(">> 생년월일 birthday: " + signupRequest.getBirth());
             authService.signup(signupRequest);
             return ResponseEntity.status(HttpStatus.CREATED).body(new MessageResponse("회원가입 성공"));
         } catch (IllegalArgumentException e) {

--- a/src/main/java/com/lion/CalPick/controller/ScheduleController.java
+++ b/src/main/java/com/lion/CalPick/controller/ScheduleController.java
@@ -10,11 +10,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/schedules")
+@RequestMapping("/api/schedules/monthly")
 public class ScheduleController {
 
     private final ScheduleService scheduleService;
@@ -27,10 +28,10 @@ public class ScheduleController {
     public ResponseEntity<List<ScheduleResponseDto>> getSchedules(
             @AuthenticationPrincipal UserPrincipal currentUser,
             @RequestParam(name = "userId", required = false) String targetUserId,
-            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
-            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate
+            @RequestParam(name = "year", required = false) int year,
+            @RequestParam(name = "month", required = false) int month
     ) {
-        List<ScheduleResponseDto> schedules = scheduleService.getSchedules(currentUser, targetUserId, startDate, endDate);
+        List<ScheduleResponseDto> schedules = scheduleService.getSchedules(currentUser, targetUserId, year, month);
         return ResponseEntity.ok(schedules);
     }
 

--- a/src/main/java/com/lion/CalPick/domain/User.java
+++ b/src/main/java/com/lion/CalPick/domain/User.java
@@ -9,6 +9,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import java.time.LocalDate;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -31,6 +32,9 @@ public class User implements UserDetails {
 
     @Column(nullable = false)
     private String nickname;
+
+    @Column(nullable = false)
+    private LocalDate birth;
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/src/main/java/com/lion/CalPick/dto/SignUpRequest.java
+++ b/src/main/java/com/lion/CalPick/dto/SignUpRequest.java
@@ -1,7 +1,10 @@
 package com.lion.CalPick.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Getter;
 import lombok.Setter;
+
+import java.time.LocalDate;
 
 @Getter
 @Setter
@@ -9,4 +12,6 @@ public class SignUpRequest {
     private String userId;
     private String password;
     private String nickname;
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate birth;
 }

--- a/src/main/java/com/lion/CalPick/repository/ScheduleRepository.java
+++ b/src/main/java/com/lion/CalPick/repository/ScheduleRepository.java
@@ -3,10 +3,15 @@ package com.lion.CalPick.repository;
 import com.lion.CalPick.domain.Schedule;
 import com.lion.CalPick.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
-    List<Schedule> findByUserAndStartTimeBetween(User user, LocalDateTime startTime, LocalDateTime endTime);
+    @Query("SELECT s FROM Schedule s WHERE s.user = :user AND s.endTime >= :monthStart AND s.startTime <= :monthEnd")
+    List<Schedule> findOverlappingSchedules(@Param("user") User user, @Param("monthStart") LocalDateTime monthStart, @Param("monthEnd") LocalDateTime monthEnd);
+
 }

--- a/src/main/java/com/lion/CalPick/service/AuthService.java
+++ b/src/main/java/com/lion/CalPick/service/AuthService.java
@@ -35,11 +35,13 @@ public class AuthService {
         if (userRepository.existsByUserId(signupRequest.getUserId())) {
             throw new IllegalArgumentException("이미 존재하는 아이디입니다.");
         }
-
+        System.out.println(">> 생년월일 birthday-service: " + signupRequest.getBirth());
         User user = new User();
         user.setUserId(signupRequest.getUserId());
         user.setPassword(passwordEncoder.encode(signupRequest.getPassword()));
         user.setNickname(signupRequest.getNickname());
+        user.setBirth(signupRequest.getBirth());
+        System.out.println(">> 생년월일 birthday-service2: " + user.getBirth());
 
         userRepository.save(user);
     }


### PR DESCRIPTION
## 📌 작업 내용  
- 기존 `/api/schedules/monthly` API에서 날짜 범위(startDate, endDate) 기반 조회 로직을 `year`, `month` 기반으로 리팩토링  
- `ScheduleService` 내부 로직에서 월 시작일~마지막일까지 계산하여 일정 조회  
- `ScheduleRepository`에 월 단위 일정 조회용 JPQL 쿼리 추가  
- 회원가입 시 생년월일(`birth`) 필드 추가 및 저장 처리  
  - `SignUpRequest`, `User`, `AuthService`, `AuthController`에 반영  
  - 생년월일은 `@JsonFormat(pattern = "yyyy-MM-dd")` 지정하여 JSON 직렬화/역직렬화 대응

---

## 🔜 앞으로의 과제  
- 일정 CRUD 기능 보완 및 테스트  
- 그룹 생성 기능 개발  
- 특정 그룹에 속한 구성원들의 일정을 한 번에 조회할 수 있는 API 추가 예정  

---

## 📎 참고 사항  
- `ScheduleService.getSchedules`의 파라미터 변경으로 인해, 프론트엔드에서도 연/월 기반 요청으로 수정 필요  
- `ScheduleController`의 매핑 URL(`/api/schedules/monthly`)은 명시적으로 분리해 두었으므로 다른 API와 충돌 없음

