### PR TITLE
일정에 색상(color) 태그 필드 추가 및 수정/삭제 API 구현

### DIFF
--- a/src/main/java/com/lion/CalPick/controller/ScheduleController.java
+++ b/src/main/java/com/lion/CalPick/controller/ScheduleController.java
@@ -15,7 +15,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/schedules/monthly")
+@RequestMapping("/api/schedules")
 public class ScheduleController {
 
     private final ScheduleService scheduleService;
@@ -24,7 +24,7 @@ public class ScheduleController {
         this.scheduleService = scheduleService;
     }
 
-    @GetMapping
+    @GetMapping("/monthly")
     public ResponseEntity<List<ScheduleResponseDto>> getSchedules(
             @AuthenticationPrincipal UserPrincipal currentUser,
             @RequestParam(name = "userId", required = false) String targetUserId,
@@ -42,5 +42,24 @@ public class ScheduleController {
     ) {
         ScheduleResponseDto newSchedule = scheduleService.addSchedule(currentUser, requestDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(newSchedule);
+    }
+
+    @PutMapping("/{scheduleId}")
+    public ResponseEntity<ScheduleResponseDto> updateSchedule(
+            @AuthenticationPrincipal UserPrincipal currentUser,
+            @PathVariable Long scheduleId,
+            @RequestBody ScheduleRequestDto requestDto
+    ) {
+        ScheduleResponseDto updated = scheduleService.updateSchedule(currentUser, scheduleId, requestDto);
+        return ResponseEntity.ok(updated);
+    }
+
+    @DeleteMapping("/{scheduleId}")
+    public ResponseEntity<ScheduleResponseDto> deleteSchedule(
+            @AuthenticationPrincipal UserPrincipal currentUser,
+            @PathVariable Long scheduleId
+    ) {
+        ScheduleResponseDto deleted = scheduleService.deleteSchedule(currentUser, scheduleId);
+        return ResponseEntity.ok(deleted);
     }
 }

--- a/src/main/java/com/lion/CalPick/domain/Schedule.java
+++ b/src/main/java/com/lion/CalPick/domain/Schedule.java
@@ -24,6 +24,7 @@ public class Schedule {
     private LocalDateTime startTime;
     private LocalDateTime endTime;
     private boolean isRepeating; // isRepeating 필드 추가
+    private String color;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)

--- a/src/main/java/com/lion/CalPick/dto/ScheduleRequestDto.java
+++ b/src/main/java/com/lion/CalPick/dto/ScheduleRequestDto.java
@@ -12,4 +12,5 @@ public class ScheduleRequestDto {
     private LocalDateTime startTime;
     private LocalDateTime endTime;
     private boolean isRepeating;
+    private String color;
 }

--- a/src/main/java/com/lion/CalPick/dto/ScheduleResponseDto.java
+++ b/src/main/java/com/lion/CalPick/dto/ScheduleResponseDto.java
@@ -17,6 +17,7 @@ public class ScheduleResponseDto {
     private boolean isRepeating;
     private String userId;
     private String nickname;
+    private String color;
 
     public ScheduleResponseDto(Schedule schedule) {
         this.id = schedule.getId();
@@ -27,5 +28,6 @@ public class ScheduleResponseDto {
         this.isRepeating = schedule.isRepeating();
         this.userId = schedule.getUser().getUserId();
         this.nickname = schedule.getUser().getNickname();
+        this.color = schedule.getColor();
     }
 }

--- a/src/main/java/com/lion/CalPick/repository/ScheduleRepository.java
+++ b/src/main/java/com/lion/CalPick/repository/ScheduleRepository.java
@@ -13,5 +13,4 @@ import java.util.List;
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     @Query("SELECT s FROM Schedule s WHERE s.user = :user AND s.endTime >= :monthStart AND s.startTime <= :monthEnd")
     List<Schedule> findOverlappingSchedules(@Param("user") User user, @Param("monthStart") LocalDateTime monthStart, @Param("monthEnd") LocalDateTime monthEnd);
-
 }

--- a/src/main/java/com/lion/CalPick/service/ScheduleService.java
+++ b/src/main/java/com/lion/CalPick/service/ScheduleService.java
@@ -85,6 +85,7 @@ public class ScheduleService {
         schedule.setEndTime(requestDto.getEndTime());
         schedule.setRepeating(requestDto.isRepeating());
         schedule.setUser(owner);
+        schedule.setColor(requestDto.getColor());
 
         Schedule savedSchedule = scheduleRepository.save(schedule);
         return new ScheduleResponseDto(savedSchedule);
@@ -108,6 +109,7 @@ public class ScheduleService {
         updatedSchedule.setStartTime(requestDto.getStartTime());
         updatedSchedule.setEndTime(requestDto.getEndTime());
         updatedSchedule.setRepeating(requestDto.isRepeating());
+        updatedSchedule.setColor(requestDto.getColor());
 
 
         Schedule savedSchedule = scheduleRepository.save(updatedSchedule);

--- a/src/main/java/com/lion/CalPick/service/ScheduleService.java
+++ b/src/main/java/com/lion/CalPick/service/ScheduleService.java
@@ -90,6 +90,48 @@ public class ScheduleService {
         return new ScheduleResponseDto(savedSchedule);
     }
 
+    @Transactional
+    public ScheduleResponseDto updateSchedule(UserPrincipal currentUserPrincipal, Long scheduleId, ScheduleRequestDto requestDto) {
+        Schedule updatedSchedule = scheduleRepository.findById(scheduleId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        User owner = userService.findById(currentUserPrincipal.getId())
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        // 수정 권한 확인
+        if (!updatedSchedule.getUser().getId().equals(owner.getId())) {
+            throw new IllegalArgumentException("수정 권한이 없습니다.");
+        }
+
+        updatedSchedule.setTitle(requestDto.getTitle());
+        updatedSchedule.setDescription(requestDto.getDescription());
+        updatedSchedule.setStartTime(requestDto.getStartTime());
+        updatedSchedule.setEndTime(requestDto.getEndTime());
+        updatedSchedule.setRepeating(requestDto.isRepeating());
+
+
+        Schedule savedSchedule = scheduleRepository.save(updatedSchedule);
+        return new ScheduleResponseDto(savedSchedule);
+    }
+
+    @Transactional
+    public ScheduleResponseDto deleteSchedule(UserPrincipal currentUserPrincipal, Long scheduleId) {
+        Schedule deletedSchedule = scheduleRepository.findById(scheduleId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        User owner = userService.findById(currentUserPrincipal.getId())
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        // 수정 권한 확인
+        if (!deletedSchedule.getUser().getId().equals(owner.getId())) {
+            throw new IllegalArgumentException("삭제 권한이 없습니다.");
+        }
+        ScheduleResponseDto deletedScheduleDto = new ScheduleResponseDto(deletedSchedule);
+        scheduleRepository.deleteById(scheduleId);
+        return deletedScheduleDto; // 삭제된 데이터 정보 반환
+    }
+
+
     // For testing purposes or initial data setup
     @Transactional
     public Schedule saveSchedule(Schedule schedule) {


### PR DESCRIPTION
## 📌 작업 내용  
일정 등록, 조회, 수정 기능에 color(색상 태그) 파라미터를 추가하였습니다.
각 일정마다 색상을 구분할 수 있도록 하기 위함이며, 프론트엔드에서 태그별 색상 구분이 가능해집니다.
Schedule 엔티티 및 DTO(Request/Response)에 color 필드를 추가하고, 서비스/컨트롤러에서 로직을 반영했습니다.
일정 수정/삭제 API도 컨트롤러에 추가하여 전체 일정 관리 기능을 완성했습니다.

---

## 🔜 앞으로의 과제  
프론트엔드와 통합 테스트를 진행하며 컬러 태그 선택 UI 연동
color 필드의 검증 로직 및 고정 색상 리스트 enum화 고려

---

## 📎 참고 사항 (선택)  
현재는 String color로 단순 처리했으나, 향후에는 프리셋 기반으로 제한하거나 HEX 코드 검증 등 추가 고려 필요합니다.
